### PR TITLE
Excludes jar from war file causing juli Log conflict.

### DIFF
--- a/synctoolui/src/main/assembly/dep.xml
+++ b/synctoolui/src/main/assembly/dep.xml
@@ -55,6 +55,7 @@
           <exclude>WEB-INF/lib/htmlunit*</exclude>
           <exclude>WEB-INF/lib/httpclient*</exclude>
           <exclude>WEB-INF/lib/org.apache.jasper*</exclude>
+          <exclude>WEB-INF/lib/apache-jsp*</exclude>
           <exclude>WEB-INF/lib/org.objenisis*</exclude>
           <exclude>WEB-INF/lib/xalan*</exclude>
           <exclude>WEB-INF/lib/css*</exclude>


### PR DESCRIPTION
**Excludes jar from war file causing juli Log conflict**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-1209
